### PR TITLE
Add support for DECIMAL annotation type

### DIFF
--- a/lib/codec/plain.js
+++ b/lib/codec/plain.js
@@ -26,6 +26,32 @@ function decodeValues_BOOLEAN(cursor, count) {
   return values;
 }
 
+function encodeValues_DECIMAL(values, opts) {
+  switch (opts.type) {
+    case 'INT32':
+      return encodeValues_INT32(values);
+    case 'INT64':
+      return encodeValues_INT64(values);
+    case 'FIXED_LEN_BYTE_ARRAY':
+      return encodeValues_FIXED_LEN_BYTE_ARRAY(values, opts);
+    default:
+      return encodeValues_INT32(values);
+  }
+}
+
+function decodeValues_DECIMAL(cursor, count, opts) {
+  switch (opts.type) {
+    case 'INT32':
+      return decodeValues_INT32(cursor, count);
+    case 'INT64':
+      return decodeValues_INT64(cursor, count);
+    case 'FIXED_LEN_BYTE_ARRAY':
+      return decodeValues_FIXED_LEN_BYTE_ARRAY(cursor, count);
+    default:
+      return decodeValues_INT32(cursor, count);
+  }
+}
+
 function encodeValues_INT32(values) {
   let buf = Buffer.alloc(4 * values.length);
   for (let i = 0; i < values.length; i++) {
@@ -213,6 +239,9 @@ exports.encodeValues = function(type, values, opts) {
     case 'BOOLEAN':
       return encodeValues_BOOLEAN(values);
 
+    case 'DECIMAL':
+      return encodeValues_DECIMAL(values, opts);
+
     case 'INT32':
       return encodeValues_INT32(values);
 
@@ -245,6 +274,9 @@ exports.decodeValues = function(type, cursor, count, opts) {
 
     case 'BOOLEAN':
       return decodeValues_BOOLEAN(cursor, count);
+
+    case 'DECIMAL':
+      return decodeValues_DECIMAL(cursor, count, opts);
 
     case 'INT32':
       return decodeValues_INT32(cursor, count);

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -112,13 +112,13 @@ class ParquetReader {
 
   /**
    * Open the parquet file from a url using the supplied request module
-   * params should either be a string (url) or an object that includes 
-   * a `url` property.  
+   * params should either be a string (url) or an object that includes
+   * a `url` property.
    * This function returns a new parquet reader
    */
   static async openUrl(request, params, options) {
     let envelopeReader = await ParquetEnvelopeReader.openUrl(request, params, options);
-    return this.openEnvelopeReader(envelopeReader, options); 
+    return this.openEnvelopeReader(envelopeReader, options);
   }
 
   static async openEnvelopeReader(envelopeReader, opts) {
@@ -215,7 +215,7 @@ class ParquetReader {
     columnList = columnList.map((x) => x.constructor === Array ? x : [x]);
 
     return new ParquetCursor(
-        this.metadata, 
+        this.metadata,
         this.envelopeReader,
         this.schema,
         columnList);
@@ -264,7 +264,7 @@ class ParquetReader {
           }
         }
       }
-      
+
       if (value instanceof Int64) {
         if (isFinite(value)) {
           return +value;
@@ -630,10 +630,10 @@ function decodeStatisticsValue(value, column) {
     return undefined;
   }
   if (!column.primitiveType.includes('BYTE_ARRAY')) {
-    value = decodeValues(column.primitiveType,'PLAIN',{buffer: Buffer.from(value), offset: 0}, 1, column);
+    value = decodeValues(column.primitiveType, 'PLAIN', { buffer: Buffer.from(value), offset: 0 }, 1, column);
     if (value.length === 1) value = value[0];
   }
-  
+
   if (column.originalType) {
     value = parquet_types.fromPrimitive(column.originalType, value);
   }
@@ -663,7 +663,7 @@ function decodePage(cursor, opts) {
   const pageHeader = new parquet_thrift.PageHeader();
 
   const headerOffset = cursor.offset;
-  const headerSize = parquet_util.decodeThrift(pageHeader, cursor.buffer.slice(cursor.offset)); 
+  const headerSize = parquet_util.decodeThrift(pageHeader, cursor.buffer.slice(cursor.offset));
   cursor.offset += headerSize;
 
 
@@ -751,7 +751,7 @@ function decodePages(buffer, opts) {
 
   return data;
 }
- 
+
 function decodeDictionaryPage(cursor, header, opts) {
   const cursorEnd = cursor.offset + header.compressed_page_size;
 
@@ -801,7 +801,7 @@ function decodeDataPage(cursor, header, opts) {
   }
 
 
-  
+
   /* read repetition levels */
   let rLevelEncoding = parquet_util.getThriftEnum(
       parquet_thrift.Encoding,
@@ -835,7 +835,7 @@ function decodeDataPage(cursor, header, opts) {
   } else {
     dLevels.fill(0);
   }
- 
+
   /* read values */
   let valueCountNonNull = 0;
   for (let dlvl of dLevels) {
@@ -973,7 +973,7 @@ function decodeSchema(schemaElements) {
           /* define parent and num_children as non-enumerable */
           parent: {
             value: schema,
-            enumerable: false 
+            enumerable: false
           },
           num_children: {
             value: schemaElement.num_children,
@@ -997,8 +997,10 @@ function decodeSchema(schemaElements) {
       schema[schemaElement.name] = {
         type: logicalType,
         typeLength: schemaElement.type_length,
+        scale: schemaElement.scale,
+        precision: schemaElement.precision,
         optional: optional,
-        repeated: repeated
+        repeated: repeated,
       };
     }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -7,6 +7,10 @@ const PARQUET_LOGICAL_TYPES = {
     toPrimitive: toPrimitive_BOOLEAN,
     fromPrimitive: fromPrimitive_BOOLEAN
   },
+  'DECIMAL': {
+    primitiveType: 'DECIMAL',
+    toPrimitive: toPrimitive_DECIMAL
+  },
   'INT32': {
     primitiveType: 'INT32',
     toPrimitive: toPrimitive_INT32
@@ -170,6 +174,10 @@ function toPrimitive_BOOLEAN(value) {
 
 function fromPrimitive_BOOLEAN(value) {
   return !!value;
+}
+
+function toPrimitive_DECIMAL(value) {
+  return toPrimitive_INT32(value);
 }
 
 function toPrimitive_FLOAT(value) {


### PR DESCRIPTION
Add support for DECIMAL annotation type, as described here: https://github.com/apache/parquet-format/blob/2e23a1168f50e83cacbbf970259a947e430ebe3a/LogicalTypes.md#decimal

It handle `int32`, `int64` and `fixed_len_byte_array`, however `binary` has been left out as well as precision enforcement.